### PR TITLE
JS.ORG CLEANUP (#35)

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -41,9 +41,6 @@
 var cnames_active = {
   "": "js-org.github.io",
   "bad-automatic-contact": "js-org-cleanup.github.io/test-repo-2",
-  "bad-automatic-fail": "js-org-cleanup.github.io/test-repo-3",
-  "bad-external-target": "custom-target.test.com",
-  "bad-non-existent-repo": "js-org-cleanup.github.io",
   "macosnotif": "mattipv4.github.io/macOSNotifJS"
   /*
   * please don't add your subdomain records down here!


### PR DESCRIPTION
# JS.ORG CLEANUP

Hello, it seems a `js.org` subdomain that was requested to target this repository no longer works.
The subdomain requested was `{{CNAME}}.js.org` and had the target of `{{TARGET}}`.
It produced the following failures when tested as part of the cleanup:
 - [HTTP](http://{{CNAME}}.js.org): `{{HTTP}}`
 - [HTTPS](https://{{CNAME}}.js.org): `{{HTTPS}}`

To keep the `js.org` subdomain you should add a page with [reasonable content](https://github.com/js-org/js.org/wiki/No-Content) within a month so the subdomain passes the validation.
Failure to rectify the issues will result in the requested subdomain being removed from JS.ORGs DNS and the list of active subdomains.

**If you are wanting to keep the `js.org` subdomain and have added [reasonable content](https://github.com/js-org/js.org/wiki/No-Content), YOU MUST reply to the [main cleanup issue]({{ISSUE}}) with the response format detailed at the top to keep the requested subdomain.**


_:robot: Beep boop. I am a robot and performed this action automatically as part of the js.org cleanup process. If you have an issue, please contact the [js.org maintainers](https://github.com/js-org-cleanup/test-repo-1/issues/new)._
