### PR TITLE
JS.ORG CLEANUP (#35)

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -41,9 +41,6 @@
 var cnames_active = {
   "": "js-org.github.io",
   "bad-automatic-contact": "js-org-cleanup.github.io/test-repo-2",
-  "bad-automatic-fail": "js-org-cleanup.github.io/test-repo-3",
-  "bad-external-target": "custom-target.test.com",
-  "bad-non-existent-repo": "js-org-cleanup.github.io",
   "macosnotif": "mattipv4.github.io/macOSNotifJS"
   /*
   * please don't add your subdomain records down here!


### PR DESCRIPTION
# JS.ORG CLEANUP

This pull request updates the cnames_active.js file following the [js.org cleanup](https://github.com/js-org-cleanup/test-repo-1/issues/35).

The following entries are removed in this pull request as they were not claimed in the [cleanup issue](https://github.com/js-org-cleanup/test-repo-1/issues/35):

 - bad-automatic-fail
 - bad-external-target
 - bad-non-existent-repo


_:robot: Beep boop. I am a robot and performed this action automatically as part of the js.org cleanup process. If you have an issue, please contact the [js.org maintainers](https://github.com/js-org-cleanup/test-repo-1/issues/new)._
