### PR TITLE
JS.ORG CLEANUP (#46)

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -41,9 +41,6 @@
 var cnames_active = {
   "": "js-org.github.io",
   "bad-automatic-contact": "js-org-cleanup.github.io/simulated-automatic-contact",
-  "bad-automatic-fail": "js-org-cleanup.github.io/simulated-automatic-fail",
-  "bad-external-target": "custom-target.test.com",
-  "bad-non-existent-repo": "js-org-cleanup.github.io",
   "macosnotif": "mattipv4.github.io/macOSNotifJS"
   /*
   * please don't add your subdomain records down here!


### PR DESCRIPTION
# JS.ORG CLEANUP

This pull request updates the cnames_active.js file following the [js.org cleanup](https://github.com/js-org-cleanup/simulated-js.org/issues/46).
This closes #46.

The following entries are removed in this pull request as they were not claimed in the [cleanup issue](https://github.com/js-org-cleanup/simulated-js.org/issues/46):

 - [bad-automatic-fail.js.org](http://bad-automatic-fail.js.org)
 - [bad-external-target.js.org](http://bad-external-target.js.org)
 - [bad-non-existent-repo.js.org](http://bad-non-existent-repo.js.org)

The following entries were listed in the [cleanup issue](https://github.com/js-org-cleanup/simulated-js.org/issues/46) but are now working, so are not being removed:

*None*


_:robot: Beep boop. I am a robot and performed this action automatically as part of the js.org cleanup process. If you have an issue, please contact the [js.org maintainers](https://github.com/js-org-cleanup/simulated-js.org/issues/new)._
